### PR TITLE
Adds new People page

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -4,29 +4,33 @@ hlapp:
   name: Hilmar Lapp
   web: http://lappland.io
   email: hilmar.lapp@duke.edu
-  bio: "Phylorerencing PI. "
+  bio: "Phylorerencing PI. Making descriptive observations fully computable."
+  fullbio: "Hilmar has been at the intersection of biology, computer science, and informatics since high school. He cares deeply about making software, data, and other scientific products reusable, reproducible, and interoperable, in particular for the long tail of small science. For the past 10 years, his research has focused on availing the vast  amount of descriptive biodiversity data to computational data science, in particular through the Phenoscape project, where he is co-PI."
   avatar: HilmarLapp-avatar-160px.jpg
   github: hlapp
   twitter: hlapp
-  google:
-    plus: +HilmarLapp
+  googleplus: +HilmarLapp
+  scholar: http://orcid.org/0000-0001-9107-0714
 
 ncellinese:
   name: Nico Cellinese
+  web: http://www.flmnh.ufl.edu/museum-voices/nico-cellinese/
   email: ncellinese@flmnh.ufl.edu
   bio: "Phyloreferencing PI. Is all about Systematics & Evolution, Biogeography, Phyloinformatics, Biodiversity Informatics."
+  fullbio: "Nico’s research lies at the interface of biodiversity science and informatics. She aims at more effectively bridging the synergies of plant systematics, evolution, biogeography, and informatics in innovative ways. Nico has been involved with selected aspects of the PhyloCode development, including the development of RegNum, which is the public repository of clade names and phylogenetic definitions. This has given her the opportunity to explore in depth a tree-thinking approach to nomenclature."
   avatar: NicoCellinese-avatar-160px.jpg
   github: ncellinese
   twitter: ncellinese
-  google:
-    plus: 111186454084885016182
+  googleplus: 111186454084885016182
 
 mrvaidya:
   name: Gaurav Vaidya
+  web: http://www.ggvaidya.com/
   email: gaurav@ggvaidya.com
   bio: "Thinks scientific names are the coolest things ever. Developing ways to quantify taxonomic stability. PhD student at the University of Colorado."
+  fullbio: "Gaurav thinks scientific names are the coolest things ever, not just because of their central role in biodiversity data integration but also because of their history as imperfect identifiers created over three centuries by taxonomists from around the world. He’s spent the last five years as a graduate student at CU Boulder developing techniques and measures to quantify taxonomic stability. He enjoys using his programming skills to make life easier for biodiversity researchers, which is why this project -- with software-building, name-defining and data-integrating components -- is such a perfect fit for him."
   avatar: GauravVaidya-avatar-160px.jpg
   twitter: mrvaidya
   github: gaurav
-  google:
-    plus: +GauravVaidya42
+  googleplus: +GauravVaidya42
+  scholar: http://scholar.google.com/citations?user=EGDSsloAAAAJ&hl=en 

--- a/_data/personnel.yml
+++ b/_data/personnel.yml
@@ -1,0 +1,6 @@
+# Project personnel
+
+staff:
+  - ncellinese
+  - hlapp
+  - mrvaidya

--- a/_pages/people.md
+++ b/_pages/people.md
@@ -1,0 +1,51 @@
+---
+layout: single-page
+title: People
+date: {{ date }}
+modified:
+excerpt: The Phyloreferencing Crew.
+permalink: /people/
+image:
+  feature:
+  teaser:
+  thumb:
+ads: false
+---
+
+## Project personnel
+
+<div class="tiles">
+{% for staff in site.data.personnel.staff %}
+{% assign person = site.data.authors[staff] %}
+  <div class="blog-list-item" itemscope itemtype="http://schema.org/Person">
+    {% if person.avatar %}
+	<img src="{{ site.url }}/images/{{ person.avatar }}" alt="{{ person.name }}" itemprop="image">
+    {% endif %}
+	<h4>{% if person.web %}<a href="{{ person.web }}" itemprop="name">{{ person.name }}</a>{% else %}<span itemprop="author">{{ person.name }}</span>{% endif %}</h4>
+    <p>
+    {% if person.email %}<a href="mailto:{{ person.email }}"><i class="fa fa-envelope" aria-hidden="true"></i></a> &nbsp; {% endif %}
+    {% if person.web %}<a href="{{ person.web }}" target="_blank"><i class="fa fa-link" aria-hidden="true"></i></a> &nbsp; {% endif %}
+    {% if person.github %}<a href="http://github.com/{{ person.github }}" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a> &nbsp; {% endif %}
+    {% if person.twitter %}<a href="http://twitter.com/{{ person.twitter }}" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a> &nbsp; {% endif %}
+    {% if person.scholar %}<a href="{{ person.scholar }}" target="_blank"><i class="fa fa-university" aria-hidden="true"></i></a> &nbsp; {% endif %}
+    </p>
+    <p class="author-bio" itemprop="description">{% if person.fullbio %}{{ person.fullbio }}{% else %}{{ person.bio }}{% endif %}</p>
+  </div><!-- .blog-list-item -->
+{% endfor %}
+</div><!-- /.tiles -->
+
+## Advisory Board
+
+* [Jim Balhoff][JPB] (RTI)
+* [David Baum][DAB] (University of Wisconsin, Madison)
+* [Holly Bik][HMB] (University of California, Riverside)
+* [Chris Mungall][CJM] (Lawrence Berkeley National Laboratory)
+* [Susan Perkins][SLP] (American Museum of Natural History)
+* [Michael Sanderson][MJS] (University of Arizona)
+
+[JPB]: https://orcid.org/0000-0002-8688-6599
+[DAB]: http://botany.wisc.edu/baumlab/people/david-baum/
+[HMB]: http://www.hollybik.com/about/
+[CJM]: http://biosciences.lbl.gov/profiles/chris-mungall-2/
+[MJS]: http://eeb.arizona.edu/people/dr-michael-sanderson
+[SLP]: http://www.amnh.org/our-research/staff-directory/susan-perkins/


### PR DESCRIPTION
This would replace the People section now on the front page. Please review the full bios, and I don't yet have a "Scholar" link (ORCID, Impactstory, Google Scholar or some such) for Nico. @ncellinese can you provide one that's appropriate for you?

One issue whether email links should be shown for each of us too. Right now they are, but un-obfuscated and thus subject to harvesting by spammers. There is a way to obfuscate them, but that prevents copy&pasting. Or we can just not show the emails links.