### PR TITLE
Added batch file to run website in Windows 10

### DIFF
--- a/serve-local.bat
+++ b/serve-local.bat
@@ -1,0 +1,2 @@
+rem docker build --pull -t phyloref/jekyll .
+docker run --rm --volume=%CD%:/srv/jekyll -it -e JEKYLL_ENV=production -p 127.0.0.1:4000:4000 phyloref/jekyll jekyll serve --config _config.yml,_config-dev.yml --drafts


### PR DESCRIPTION
Quick pull request for adding Windows 10 support: I've added a batch file that can run the website using Jekyll in Docker. This should make it easier for *nix and Windows development to use as close to identical Jekylls as possible.