### PR TITLE
Add PKI Validation code to website

### DIFF
--- a/.well-known/pki-validation/B3701853EA21BD57FD1910D770308213.txt
+++ b/.well-known/pki-validation/B3701853EA21BD57FD1910D770308213.txt
@@ -1,0 +1,2 @@
+9d2df4865747b815254bcedf9fcba36dea91438a4cad84fabd4588d05eb1d988
+sectigo.com

--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,7 @@ owner:
 include:
   - .htaccess
   - _pages
+  - .well-known
 exclude:
   - "*.less"
   - "*.sublime-project"


### PR DESCRIPTION
UF Research Computing have decided to get us a *.phyloref.org SSL certificate rather than one just for reasoner.phyloref.org. To do this, we need to verify that we control this domain by creating a file at http://phyloref.org/.well-known/pki-validation/B3701853EA21BD57FD1910D770308213.txt containing the text:

```
9d2df4865747b815254bcedf9fcba36dea91438a4cad84fabd4588d05eb1d988
sectigo.com
```

This PR adds this file, and modifies `_config.yml` so that this file will be accessible on the website. I've confirmed that it works locally on my computer.